### PR TITLE
TM-211 Deactivation

### DIFF
--- a/src/pages/Account/Deactivate/Deactivate.js
+++ b/src/pages/Account/Deactivate/Deactivate.js
@@ -1,9 +1,7 @@
 import { useState } from "react";
 import styles from "./Deactivate.module.css";
 import Modal from "./DeleteModal";
-import DeactivateEmailTemplate from "./DeactiviateEmailTemplate";
-import { db } from "../../../firebase";
-import { addDoc, collection } from "firebase/firestore";
+import DeactivateModal from "./DeactivateModal/DeactivateModal";
 
 /** Deactivate is a React component that displays two buttons.
  * One button is for account deactivation and the other is for delection.
@@ -13,27 +11,10 @@ import { addDoc, collection } from "firebase/firestore";
  * - user: Object that holds the user's account information
  */
 const Deactivate = ({ user }) => {
-  // State to hold Delete Modal
+  // State to hold Delete Modal and Deactivate Modal
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isDeactivateModalOpen, setIsDeactivateModalOpen] = useState(false);
 
-  /** Function to send out deactivation email when 'Deactivate' is clicked */
-  const handleDeactivate = async () => {
-    // userName: user.displayName
-    const emailTemplate = DeactivateEmailTemplate(user.displayName);
-
-    try {
-      // Adds new email document
-      const docRef = await addDoc(collection(db, "mail"), {
-        to: user.email,
-        message: {
-          subject: "Account Deactivation Confirmation",
-          html: emailTemplate,
-        },
-      });
-    } catch (error) {
-      // Error sending email
-    }
-  };
   return (
     <>
       <div className={styles.container}>
@@ -41,11 +22,17 @@ const Deactivate = ({ user }) => {
           <button
             className={styles.title}
             onClick={() => {
-              handleDeactivate();
+              setIsDeactivateModalOpen(true);
             }}
           >
             Deactivate Account
           </button>
+          {isDeactivateModalOpen && (
+            <DeactivateModal
+              closeModal={setIsDeactivateModalOpen}
+              user={user}
+            />
+          )}
           <p className={styles.text}>
             Need a break? We understand. If you are sure you want to deactivate
             your account, you may do so by selecting the link above.

--- a/src/pages/Account/Deactivate/DeactivateModal/DeactivateModal.js
+++ b/src/pages/Account/Deactivate/DeactivateModal/DeactivateModal.js
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+import styles from "../DeleteModal/DeleteModal.module.css";
+import StyledButton from "../../../../components/StyledButton/StyledButton";
+import { useNavigate } from "react-router-dom";
+import { auth, db } from "../../../../firebase";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import DeactivateEmailTemplate from "../DeactiviateEmailTemplate";
+import { signOut } from "firebase/auth";
+
+/** Modal is a React component that displays a modal dialog
+ * allows users to confirm or cancel deletion on their account
+ *
+ * Props:
+ * - closeModal: State if state to false, modal closes
+ * - user: Object that holds the user's account information
+ */
+const DeactivateModal = ({ closeModal, user }) => {
+  const navigate = useNavigate();
+
+  /** Function to deactivate account 'Continue' is clicked */
+  const handleDeactivate = async () => {
+    // grab the user doc from the firestore
+    const docRef = doc(db, "user", user.uid);
+    const userDoc = await getDoc(docRef);
+
+    // assign the users role to a varible
+    const role = userDoc.data().role;
+    try {
+      // if the user's role is a requester then delete all request
+      if (role === "requester") {
+        const q = query(
+          collection(db, "request"),
+          where("uid", "==", user.uid) // Filter by logged-in user's uid
+        );
+        const querySnapshot = await getDocs(q);
+        const requestsData = querySnapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+        requestsData.forEach((req) => {
+          deleteDoc(doc(db, "request", req.id));
+        });
+      }
+      // if user's role is an insider, set all the request they are matched on back to matching status.
+      else {
+        const q = query(
+          collection(db, "request"),
+          where("insider", "==", user.uid) // Filter by logged-in user's uid
+        );
+        const querySnapshot = await getDocs(q);
+        console.log(querySnapshot);
+        const requestsData = querySnapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+        requestsData.forEach((req) => {
+          updateDoc(doc(db, "request", req.id), {
+            insider: null,
+            status: "matching",
+          });
+        });
+      }
+
+      navigate("/signin");
+      signOut(auth);
+    } catch (error) {}
+  };
+
+  /** Function to send a deactivate email when 'Continue' is clicked */
+  const handleDeactivateEmail = async () => {
+    // userName: user's name
+    const emailTemplate = DeactivateEmailTemplate(user.displayName);
+
+    try {
+      // Adds new email document
+      await addDoc(collection(db, "mail"), {
+        to: user.email,
+        message: {
+          subject: "Account Deactivation Confirmation ",
+          html: emailTemplate,
+        },
+      });
+    } catch (error) {
+      // Error sending email
+    }
+  };
+
+  return (
+    <div className={styles.modelWrapper}>
+      <div className={styles.modalBackground}>
+        <div className={styles.modalContainer}>
+          <div className={styles.title}>
+            <img src="/images/profile/alert.svg" alt="deactivate_alert_logo" />
+            <h1>Is this goodbye?</h1>
+          </div>
+          <div className={styles.body}>
+            &nbsp;
+            <p>
+              Please note that deactivating your account will delete any request
+              you are associated with. As a reminder,
+            </p>
+            <ul>
+              <li>
+                Deactivating your account will remove all request from any
+                Insiders you are matched with.
+              </li>
+              <li>
+                Your data will not be kept and will no longer be acceptable to
+                other users.
+              </li>
+              <li>
+                Deactivated users must log back into their account if they wish
+                to use the platform again.
+              </li>
+            </ul>
+            <p>
+              If you have ay questions or concerns about deleting your account,
+              please contact our support team.
+            </p>
+          </div>
+          <div className={styles.footer}>
+            <div className={styles.buttons}>
+              <StyledButton
+                className={styles.continueBtn}
+                color="primary"
+                onClick={() => {
+                  handleDeactivate();
+                  handleDeactivateEmail();
+                }}
+              >
+                {" "}
+                Continue{" "}
+              </StyledButton>
+              <StyledButton
+                className={styles.cancelBtn}
+                onClick={() => closeModal(false)}
+                color="secondary"
+              >
+                Cancel
+              </StyledButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeactivateModal;


### PR DESCRIPTION
- [x] Added a modal to appear when the deactivate button is clicked on the ```/account``` page
- [x] Removed ```handleDeactivate()``` function from ```Deactivate.js``` moved into ```DeactivateModal.js```

- [x] Request documents removed from RequestFeed (frontend) when Requester deactivates their account.
- [x] Request documents deleted from Firestore (backend) when Requester deactivates their account

- [x] Request documents placed back on the Insider RequestFeed (frontend) from the Insider's in-progress tab when an insider deactivates.
- [x]  "matched" or "accept" statuses for request documents associated to an insider reset to "matching" status (backend) when an Insider deactivates their account.
   
- [x] confirmation email sent when deactivation is confirmed.