### PR TITLE
Tm-238: Side column of chatbox (front end only) & TM-246 (whole chat page)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import Account from "./pages/Account";
 import InsiderFeed from "./pages/RequestPage/InsiderFeed";
 import Onboarding from "./pages/Onboarding/Onboarding";
 import { RequesterFeed, RequesterForm } from "./pages/RequestPage";
+import Chat from "./pages/Chat";
 
 function App() {
   return (
@@ -30,6 +31,7 @@ function App() {
               <Route path="/request/form" element={<RequesterForm />} />
               <Route path="/request-insider" element={<InsiderFeed />} />
               <Route path="/onboarding" element={<Onboarding />} />
+              <Route path="/chat" element={<Chat />} />
             </Route>
             <Route path="/signup" element={<SignUp />} />
             <Route path="/signin" element={<SignIn />} />

--- a/src/pages/Chat/Chat.js
+++ b/src/pages/Chat/Chat.js
@@ -13,9 +13,9 @@ const Chat = () => {
 
     const { user, isAuthenticated } = useAuthState();
     //testing a message already selected
-    // const [selectedMessages, setSelectedMessages] = useState(messages[0]);
+    const [selectedMessages, setSelectedMessages] = useState(messages[0]);
     //testing a message not selected
-    const [selectedMessages, setSelectedMessages] = useState(null);
+    // const [selectedMessages, setSelectedMessages] = useState(null);
     const [numUnreadMessages, setNumUnreadMessages] = useState(1);
 
     // const testingMessagesSelected = true;

--- a/src/pages/Chat/Chat.js
+++ b/src/pages/Chat/Chat.js
@@ -4,13 +4,21 @@ import { Header } from "../../components/Typography";
 import { Navigate } from "react-router-dom";
 import { useState } from "react";
 import MessagerBar from "./components/MessagerBar";
+import SideBar from "./components/SideBar";
 
-import {messages} from "./mockData";//mock data for testing front end
+import {messages} from "./mockData"; //mock data for testing front end
+import ChatBox from "./components/ChatBox";
 
 const Chat = () => {
 
     const { user, isAuthenticated } = useAuthState();
-    const [selectedMessages, setSelectedMessages] = useState(messages[0]);
+    //testing a message already selected
+    // const [selectedMessages, setSelectedMessages] = useState(messages[0]);
+    //testing a message not selected
+    const [selectedMessages, setSelectedMessages] = useState(null);
+    const [numUnreadMessages, setNumUnreadMessages] = useState(1);
+
+    // const testingMessagesSelected = true;
 
 
 
@@ -23,7 +31,11 @@ const Chat = () => {
             <div className={styles.title}>
             <Header color="darkBlue">Messages</Header>
             </div>
-            <MessagerBar activeMessages={selectedMessages} setActiveMessages={setSelectedMessages}/>
+            <MessagerBar activeMessages={selectedMessages} numUnreadMessages={numUnreadMessages} />
+            <div className={styles.sideAndBlobContainer}>
+                <SideBar messages={messages} />
+                <ChatBox />
+            </div>
         </div>
 )
 }

--- a/src/pages/Chat/Chat.js
+++ b/src/pages/Chat/Chat.js
@@ -6,19 +6,27 @@ import { useState } from "react";
 import MessagerBar from "./components/MessagerBar";
 import SideBar from "./components/SideBar";
 
-import {messages} from "./mockData"; //mock data for testing front end
+import {conversations} from "./mockData"; //mock data for testing front end
 import ChatBox from "./components/ChatBox";
 
 const Chat = () => {
 
     const { user, isAuthenticated } = useAuthState();
     //testing a message already selected
-    const [selectedMessages, setSelectedMessages] = useState(messages[0]);
+    // const [selectedConversation, setSelectedConversation] = useState(conversations[0]);
     //testing a message not selected
-    // const [selectedMessages, setSelectedMessages] = useState(null);
-    const [numUnreadMessages, setNumUnreadMessages] = useState(1);
 
-    // const testingMessagesSelected = true;
+
+    const [selectedConversation, setSelectedConversation] = useState(null);
+    
+    //getting the number of unread messages
+    let unreadMessages = 0;
+    conversations.forEach((conversation) => {
+        if(!conversation.lastMessageRead){
+            unreadMessages++;
+        }
+    });
+    const [numUnreadMessages, setNumUnreadMessages] = useState(unreadMessages);
 
 
 
@@ -31,10 +39,14 @@ const Chat = () => {
             <div className={styles.title}>
             <Header color="darkBlue">Messages</Header>
             </div>
-            <MessagerBar activeMessages={selectedMessages} numUnreadMessages={numUnreadMessages} />
+            <MessagerBar activeMessages={selectedConversation} numUnreadMessages={numUnreadMessages} />
             <div className={styles.sideAndBlobContainer}>
-                <SideBar messages={messages} />
-                <ChatBox />
+                <SideBar 
+                    conversations={conversations} 
+                    selectedConversation={selectedConversation}
+                    setSelectedConversation={setSelectedConversation}
+                />
+                <ChatBox messages={selectedConversation}/>
             </div>
         </div>
 )

--- a/src/pages/Chat/Chat.js
+++ b/src/pages/Chat/Chat.js
@@ -1,0 +1,31 @@
+import styles from "./Chat.module.css";
+import { useAuthState } from "../../hooks/useAuthState";
+import { Header } from "../../components/Typography";
+import { Navigate } from "react-router-dom";
+import { useState } from "react";
+import MessagerBar from "./components/MessagerBar";
+
+import {messages} from "./mockData";//mock data for testing front end
+
+const Chat = () => {
+
+    const { user, isAuthenticated } = useAuthState();
+    const [selectedMessages, setSelectedMessages] = useState(messages[0]);
+
+
+
+    if (!isAuthenticated) {
+        return <Navigate replace to="/" />;
+    }
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.title}>
+            <Header color="darkBlue">Messages</Header>
+            </div>
+            <MessagerBar activeMessages={selectedMessages} setActiveMessages={setSelectedMessages}/>
+        </div>
+)
+}
+
+export default Chat

--- a/src/pages/Chat/Chat.module.css
+++ b/src/pages/Chat/Chat.module.css
@@ -8,3 +8,9 @@
     margin-bottom: 40px;
 }
 
+.sideAndBlobContainer{
+    display: flex;
+    align-items: flex-start;
+    flex: 1 0 0;
+    align-self: stretch;
+}

--- a/src/pages/Chat/Chat.module.css
+++ b/src/pages/Chat/Chat.module.css
@@ -1,0 +1,10 @@
+.container {
+    max-width: 1100px;
+    margin: 0px auto;
+  }
+  
+.title {
+    margin-top: 31px;
+    margin-bottom: 40px;
+}
+

--- a/src/pages/Chat/components/ChatBox/ChatBox.js
+++ b/src/pages/Chat/components/ChatBox/ChatBox.js
@@ -1,0 +1,11 @@
+import styles from "./ChatBox.module.css";
+
+const ChatBox = () => {
+  return (
+    <div className={styles.chatBoxWrapper}>
+        ChatBox
+    </div>
+  )
+}
+
+export default ChatBox

--- a/src/pages/Chat/components/ChatBox/ChatBox.js
+++ b/src/pages/Chat/components/ChatBox/ChatBox.js
@@ -1,9 +1,18 @@
 import styles from "./ChatBox.module.css";
 
-const ChatBox = () => {
+const ChatBox = ({messages}) => {
+  if(!messages){
+    return (
+      <div className={styles.chatBoxWrapper}>
+          <p className={styles.noMessages}>No Messages Selected</p>
+      </div>
+    )
+  }
+
+
   return (
     <div className={styles.chatBoxWrapper}>
-        ChatBox
+        {JSON.stringify(messages)}
     </div>
   )
 }

--- a/src/pages/Chat/components/ChatBox/ChatBox.module.css
+++ b/src/pages/Chat/components/ChatBox/ChatBox.module.css
@@ -1,9 +1,9 @@
-.sideBarWrapper{
+.chatBoxWrapper{
     display: flex;
-    width: 349px;
+    padding: 32px;
     flex-direction: column;
     align-items: flex-start;
+    flex: 1 0 0;
     align-self: stretch;
-    /* to visualize for testing */
-    border: 1px solid green;
+    border: 1px solid red;
 }

--- a/src/pages/Chat/components/ChatBox/ChatBox.module.css
+++ b/src/pages/Chat/components/ChatBox/ChatBox.module.css
@@ -5,5 +5,6 @@
     align-items: flex-start;
     flex: 1 0 0;
     align-self: stretch;
-    border: 1px solid red;
+    /* to visualize for testing */
+    /* border: 1px solid red; */
 }

--- a/src/pages/Chat/components/ChatBox/index.js
+++ b/src/pages/Chat/components/ChatBox/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ChatBox";

--- a/src/pages/Chat/components/MessagerBar/MessagerBar.js
+++ b/src/pages/Chat/components/MessagerBar/MessagerBar.js
@@ -2,22 +2,19 @@ import styles from "./MessagerBar.module.css";
 
 const MessagerBar = ({activeMessages, numUnreadMessages}) => {
 
+    let stringToDisplay = '';
     if(!activeMessages){
-        return (
-            <div className={styles.msgBar}>
-                <div className={styles.msgBarWrapper}>
-                    <p className={styles.msgBarText}>({numUnreadMessages}) Unread Message{numUnreadMessages === 1 ? '': 's'}</p>
-                </div>
-            </div>
-        )
+        stringToDisplay = `(${numUnreadMessages}) Unread Message${numUnreadMessages === 1 ? '': 's'}`;
     }
-    const messagerName = activeMessages.name.split(" ")[0];
-    const messagerRelationship = activeMessages.relationship;
-    console.log(activeMessages);
+    else {
+        let name = activeMessages.name.split(" ")[0];
+        let relationship = activeMessages.relationship;
+        stringToDisplay = `${name} | ${relationship}`;
+    }
     return (
         <div className={styles.msgBar}>
             <div className={styles.msgBarWrapper}>
-                <p className={styles.msgBarText}>{messagerName} | {messagerRelationship}</p>
+                <p className={styles.msgBarText}>{stringToDisplay}</p>
             </div>
             
         </div>

--- a/src/pages/Chat/components/MessagerBar/MessagerBar.js
+++ b/src/pages/Chat/components/MessagerBar/MessagerBar.js
@@ -1,0 +1,18 @@
+import styles from "./MessagerBar.module.css";
+
+const MessagerBar = ({activeMessages}) => {
+
+    const messagerName = activeMessages.name.split(" ")[0];
+    const messagerRelationship = activeMessages.relationship;
+    console.log(activeMessages);
+    return (
+        <div className={styles.msgBar}>
+            <div className={styles.msgBarWrapper}>
+                <p className={styles.msgBarText}>{messagerName} | {messagerRelationship}</p>
+            </div>
+            
+        </div>
+    )
+}
+
+export default MessagerBar

--- a/src/pages/Chat/components/MessagerBar/MessagerBar.js
+++ b/src/pages/Chat/components/MessagerBar/MessagerBar.js
@@ -1,7 +1,16 @@
 import styles from "./MessagerBar.module.css";
 
-const MessagerBar = ({activeMessages}) => {
+const MessagerBar = ({activeMessages, numUnreadMessages}) => {
 
+    if(!activeMessages){
+        return (
+            <div className={styles.msgBar}>
+                <div className={styles.msgBarWrapper}>
+                    <p className={styles.msgBarText}>({numUnreadMessages}) Unread Message{numUnreadMessages === 1 ? '': 's'}</p>
+                </div>
+            </div>
+        )
+    }
     const messagerName = activeMessages.name.split(" ")[0];
     const messagerRelationship = activeMessages.relationship;
     console.log(activeMessages);

--- a/src/pages/Chat/components/MessagerBar/MessagerBar.module.css
+++ b/src/pages/Chat/components/MessagerBar/MessagerBar.module.css
@@ -1,0 +1,28 @@
+.msgBarText {
+    color: #222f65;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 700;
+    font-style: normal;
+    line-height: 24px;
+
+}
+
+.msgBarWrapper{
+    /* display: flex; */
+    padding: 16px 0px;
+    align-items: center;
+    /* gap: 8px; */
+    flex: 1 0 0;
+}
+
+.msgBar {
+    width: 100%;
+    margin: 0 auto;
+    background-color: #EFF2FC;
+    border-radius: 9px 9px 0 0;
+    border-bottom: 1px solid #DEDEDE;
+    display: flex;
+    align-items: flex-start;
+    align-self: stretch;
+}

--- a/src/pages/Chat/components/MessagerBar/index.js
+++ b/src/pages/Chat/components/MessagerBar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./MessagerBar";

--- a/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.js
+++ b/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.js
@@ -1,0 +1,53 @@
+import styles from './ConversationCard.module.css'
+
+
+const ConversationCard = ({conversation, currentlyActive, setSelectedConversation}) => {
+    //check if there are any messages in the conversation
+    let lastMessage;
+    let lastMessageTime = new Date();
+    if(conversation.messages.length === 0){
+        lastMessage = {content: 'Request Accepted, start a chat!'};
+    }
+    else{
+        //get the last message in the array
+        lastMessage = conversation.messages[conversation.messages.length - 1];
+        //get the last message time
+        lastMessageTime = new Date(lastMessage.timestamp);
+    }
+
+    //trim the last message to 32 characters
+    const lastMessageTrimmed = lastMessage.content.length > 32 ? `${lastMessage.content.substring(0, 32)}...` : lastMessage.content;
+
+
+    //convert time to Month Day from timestamp
+    const month = lastMessageTime.toLocaleString('default', { month: 'short' });
+    const day = lastMessageTime.getDate();
+    const year = lastMessageTime.toLocaleDateString('en', {year: '2-digit'});
+    //check if year is current year
+    const currentYear = new Date().toLocaleDateString('en', {year: '2-digit'});
+    //if year is current year, don't display year
+    const lastMessageTimeFormatted = `${month} ${day} ${year === currentYear ? '' : `'${year}`}`;
+
+    return (
+        <div 
+            onClick={() => setSelectedConversation(conversation)}    
+            className={`${styles.convoCard} ${currentlyActive ? styles.convoCardActive : ''}`}
+        >
+            <img className={styles.convoCardImage} src={conversation.image} alt={`${conversation.name} headshot`} />
+            <div className={styles.convoCardInfo}>
+                <div className={styles.convoCardHeader}>
+                <div className={styles.convoCardName}>{conversation.name}</div>
+                <div className={styles.convoCardHeaderInfo}>
+                    <div className={styles.convoCardTime}>{lastMessageTimeFormatted}</div>
+                    {!conversation.lastMessageRead &&(
+                    <div className={styles.convoCardNotification}></div>
+                    )}
+                </div>
+                </div>
+                <div className={styles.sideBarChatMessage}>{lastMessageTrimmed}</div>
+            </div>
+        </div>
+    )
+}
+
+export default ConversationCard

--- a/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.js
+++ b/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.js
@@ -21,12 +21,29 @@ const ConversationCard = ({conversation, currentlyActive, setSelectedConversatio
 
     //convert time to Month Day from timestamp
     const month = lastMessageTime.toLocaleString('default', { month: 'short' });
+    //get the month number
+    const monthNumber = lastMessageTime.getMonth();
     const day = lastMessageTime.getDate();
     const year = lastMessageTime.toLocaleDateString('en', {year: '2-digit'});
     //check if year is current year
     const currentYear = new Date().toLocaleDateString('en', {year: '2-digit'});
-    //if year is current year, don't display year
-    const lastMessageTimeFormatted = `${month} ${day} ${year === currentYear ? '' : `'${year}`}`;
+    //check if it is the current day
+    const currentDay = new Date().getDate();
+    //check if it is the current month
+    const currentMonth = new Date().toLocaleString('default', { month: 'short' });
+
+    let lastMessageTimeFormatted;
+    //if it is the current day, month and year
+    if(currentYear === year && currentDay === day && currentMonth === month){
+        lastMessageTimeFormatted = lastMessageTime.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+    }
+    //else if it is the current year
+    else if(currentYear === year){
+        lastMessageTimeFormatted = `${month} ${day}`;
+    }
+    else{
+        lastMessageTimeFormatted = `${monthNumber+1}/${day}/${year}`;
+    }
 
     return (
         <div 

--- a/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.module.css
+++ b/src/pages/Chat/components/SideBar/ConversationCard/ConversationCard.module.css
@@ -1,0 +1,83 @@
+:root{
+    --blue-Fill: #EFF2FC;
+    --secondary: #DEDEDE;
+    --dark-blue-header: #222F65;
+    --light-grey: #515151;
+    --red: #D62B28;
+}
+.convoCard{
+    display: flex;
+    padding: 16px;
+    align-items: center;
+    align-items: center;
+    gap: 24px;
+    align-self: stretch;
+    cursor: pointer;
+    border-bottom: 1px solid var(--secondary);
+}
+
+.convoCardActive{
+    background: var(--blue-Fill);
+    border-left: 6px solid var(--dark-blue-header);
+}
+
+.convoCard:hover{
+    background: var(--secondary);
+}
+
+.convoCardImage{
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+}
+
+.convoCardInfo{
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    flex: 1 0 0;
+}
+
+.convoCardHeader{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    align-self:stretch;
+}
+
+.convoCardName{
+    color: var(--dark-blue-header, #222F65);
+    font-feature-settings: 'clig' off, 'liga' off;
+    font-family: "PT Sans";
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 24px; /* 133.333% */
+}
+
+.convoCardHeaderInfo{
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.convoCardTime{
+    color: var(--light-grey, #515151);
+    font-feature-settings: 'clig' off, 'liga' off;
+
+    /* Body 1 */
+    font-family: "PT Sans";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 125%; /* 20px */
+}
+
+.convoCardNotification{
+    width: 8px;
+    height: 8px;
+    border-radius: 100px;
+    background: var(--red, #D62B28);
+}

--- a/src/pages/Chat/components/SideBar/ConversationCard/index.js
+++ b/src/pages/Chat/components/SideBar/ConversationCard/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ConversationCard";

--- a/src/pages/Chat/components/SideBar/SideBar.js
+++ b/src/pages/Chat/components/SideBar/SideBar.js
@@ -2,7 +2,9 @@ import styles from "./SideBar.module.css";
 
 const SideBar = () => {
   return (
-    <div>SideBar</div>
+    <div className={styles.sideBarWrapper}>
+        SideBar
+    </div>
   )
 }
 

--- a/src/pages/Chat/components/SideBar/SideBar.js
+++ b/src/pages/Chat/components/SideBar/SideBar.js
@@ -1,0 +1,9 @@
+import styles from "./SideBar.module.css";
+
+const SideBar = () => {
+  return (
+    <div>SideBar</div>
+  )
+}
+
+export default SideBar

--- a/src/pages/Chat/components/SideBar/SideBar.js
+++ b/src/pages/Chat/components/SideBar/SideBar.js
@@ -1,10 +1,23 @@
 import styles from "./SideBar.module.css";
+import ConversationCard from "./ConversationCard";
 
-const SideBar = () => {
+const SideBar = ({conversations, selectedConversation, setSelectedConversation}) => {
+
+  // const click = (conversation) => {
+
   return (
-    <div className={styles.sideBarWrapper}>
-        SideBar
-    </div>
+    <aside className={styles.sideBarWrapper}>
+        <div className={styles.sideBarAllChats}>
+            {conversations.map((conversation, index) => 
+              <ConversationCard 
+                conversation={conversation} 
+                key={index}
+                currentlyActive={selectedConversation === conversation} 
+                setSelectedConversation={setSelectedConversation}  
+              />
+            )}
+        </div>
+    </aside>
   )
 }
 

--- a/src/pages/Chat/components/SideBar/SideBar.module.css
+++ b/src/pages/Chat/components/SideBar/SideBar.module.css
@@ -1,3 +1,11 @@
+:root{
+    --blue-Fill: #EFF2FC;
+    --secondary: #DEDEDE;
+    --dark-blue-header: #222F65;
+    --light-grey: #515151;
+    --red: #D62B28;
+}
+
 .sideBarWrapper{
     display: flex;
     width: 349px;
@@ -5,5 +13,14 @@
     align-items: flex-start;
     align-self: stretch;
     /* to visualize for testing */
-    border: 1px solid green;
+    /* border: 1px solid green; */
+}
+
+.sideBarAllChats{
+    display: flex;
+    width: 349px;
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    border: 1px solid var(--blue-Fill);
 }

--- a/src/pages/Chat/components/SideBar/index.js
+++ b/src/pages/Chat/components/SideBar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SideBar";

--- a/src/pages/Chat/index.js
+++ b/src/pages/Chat/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Chat";

--- a/src/pages/Chat/mockData.js
+++ b/src/pages/Chat/mockData.js
@@ -1,0 +1,102 @@
+//mock data for testing front end
+export const messages = [
+    {
+        id: 1,
+        name: "Person A",
+        messages: [
+            {
+                "id": 1,
+                "content": "Hello",
+                "timestamp": "2021-10-01T12:00:00Z"
+            },
+            {
+                "id": 2,
+                "content": "Hi",
+                "timestamp": "2021-10-01T12:01:00Z"
+            }
+        ],
+        lastMessageRead: true,
+        relationship: "Product Manager Requester",
+        image: "/images/landing_page/frank_avatar.png",
+    },
+    //test case for no messages (Request accepted, start a chat)
+    {
+        id: 2,
+        name: "Dan Danerson",
+        messages: [
+            {
+                "id": 1,
+                "content": "Hello",
+                "timestamp": "2021-10-01T12:00:00Z"
+            },
+            {
+                "id": 2,
+                "content": "Hi",
+                "timestamp": "2021-10-01T12:01:00Z"
+            }
+        ],
+        lastMessageRead: true,
+        relationship: "SWE Requester",
+        image: "/images/landing_page/arron_avatar.png",
+    },
+    {
+        id: 3,
+        name: "Sally Sallerson",
+        messages: [
+            {
+                "id": 1,
+                "content": "Hi Sally are you avaialble to chat?",
+                "timestamp": "2023-10-01T12:00:00Z"
+            },
+            {
+                "id": 2,
+                "content": "Yes I am, here is a Zoom link: https://zoom.us/j/1234567890",
+                "timestamp": "2023-10-01T12:01:00Z"
+            }
+        ],
+        lastMessageRead: true,
+        relationship: "Design Requester",
+        image: "/images/landing_page/al_avatar.png",
+    },
+    //test case: for a draft message
+    {
+        id: 4,
+        name: "Janet Janeterson",
+        messages: [
+            {
+                "id": 1,
+                "content": "Hi, are you avaialble to chat?",
+                "timestamp": "2023-10-01T12:00:00Z"
+            },
+            {
+                "id": 2,
+                "content": "Yes I am, but not right now, in 10 minutes. here is a Zoom link: https://zoom.us/j/1234567890",
+                "timestamp": "2023-10-01T12:01:00Z"
+            }
+        ],
+        lastMessageRead: true,
+        relationship: "Product Manager Requester",
+        image: "/images/landing_page/frank_avatar.png",
+    },
+    {
+        id: 4,
+        name: "Erica Ericson",
+        messages: [
+            {
+                "id": 1,
+                "content": "Hi, are you avaialble to chat?",
+                "timestamp": "2023-10-01T12:00:00Z"
+            },
+            {
+                "id": 2,
+                "content": "Hellooooo",
+                "timestamp": "2023-10-01T12:01:00Z"
+            }
+        ],
+        lastMessageRead: false,
+        relationship: "SWE Requester",
+        image: "/images/landing_page/arron_avatar.png",
+    },
+
+
+]

--- a/src/pages/Chat/mockData.js
+++ b/src/pages/Chat/mockData.js
@@ -1,5 +1,5 @@
 //mock data for testing front end
-export const messages = [
+export const conversations = [
     {
         id: 1,
         name: "Person A",
@@ -54,7 +54,7 @@ export const messages = [
                 "timestamp": "2023-10-01T12:01:00Z"
             }
         ],
-        lastMessageRead: true,
+        lastMessageRead: false,
         relationship: "Design Requester",
         image: "/images/landing_page/al_avatar.png",
     },
@@ -90,12 +90,22 @@ export const messages = [
             {
                 "id": 2,
                 "content": "Hellooooo",
-                "timestamp": "2023-10-01T12:01:00Z"
+                "timestamp": "2024-02-01T12:01:00Z"
             }
         ],
         lastMessageRead: false,
         relationship: "SWE Requester",
         image: "/images/landing_page/arron_avatar.png",
+    },
+    //test case no messages
+    {
+        id: 5,
+        name: "Ash Ketchem",
+        messages: [
+        ],
+        lastMessageRead: true,
+        relationship: "SWE Requester",
+        image: "/images/landing_page/al_avatar.png",
     },
 
 

--- a/src/pages/Landing/components/HeroItem/HeroItem.module.css
+++ b/src/pages/Landing/components/HeroItem/HeroItem.module.css
@@ -25,7 +25,7 @@
 
 .heroRightLogo {
   width: 100%;
-  height: 100%;
+  /* height: 100%; */
 }
 
 .heroCenterText {


### PR DESCRIPTION
From Jira Ticket TM-238

- [x] As an Teamwyrk user, When I start or receive a chat. I would want to be able to see the chat populate on a side bar next to the chat box with the name, profile picture of the person I am communicating with.
- [x] As a Teamwyrk user, I would like for the side column to be able to display a preview of the content of the most recent sent or received message, and I would like to have a time stamp displayed in the side column on when that message has been received/sent.
- [ ] As a Teamwyrk user, I would like to be able to have the most recent chat be positioned on the top of the Side column and have it listed in reversed chronological order (listed from most recent on top - oldest chat on the bottom). (Pending once mockData is not used)

![tm-238](https://github.com/noscenthairspray/Teamwyrk/assets/12940551/6ba24c16-7e8c-465a-8a3d-4177450f4325)
